### PR TITLE
Update 2024-class-monk.xml - Fixed typos in Elemental Warrior level 3

### DIFF
--- a/2024-class-monk.xml
+++ b/2024-class-monk.xml
@@ -639,11 +639,11 @@
 		<description>
 			<p><em>3rd-level Warrior of the Elements feature</em></p>
 			<p>At the start of your turn, you can spend 1 Focus Point to imbue yourself with elemental energy. The energy lasts for 10 minutes or until you have the Incapacitated condition. You gain the following benefits for the duration:</p>
-			<p><strong>Elemental Strikes.</strong> Whenever you hit with your Unarmed Strike, you can cause it to deal your choice of  Acid, Cold, Fire, Lightning, or Thunder damage rather than its normal damage type. When you deal one of these types with your Unarmed Strike, you can also force the target to make a Strength saving throw. On a failed save, you can move the target up to 10 feet toward or away from you, as elemental energy swirls around it.</p>
+			<p><strong>Elemental Strikes.</strong> Whenever you hit with your Unarmed Strike, you can cause it to deal your choice of Acid, Cold, Fire, Lightning, or Thunder damage rather than its normal damage type. When you deal one of these types with your Unarmed Strike, you can also force the target to make a Strength saving throw. On a failed save, you can move the target up to 10 feet toward or away from you, as elemental energy swirls around it.</p>
 			<p><strong>Reach.</strong> When you make an Unarmed Strike, your reach is 10 feet greater than normal, as elemental energy extends from you.</p>
 		</description>
 		<sheet usage="1 Focus">
-			<description>At start of turn, imbue yourself with elemental energy for 10 min. Unarmed reach increases by 10ft, Unarmed strikes can deal Acid, Cold, Fire, or Lightning damage rather than its normal damage type and can force a STR save. On a failed save, you can move the target 10ft toward or away from you.
+			<description>At start of turn, imbue yourself with elemental energy for 10 min. Unarmed reach increases by 10ft, Unarmed strikes can deal Acid, Cold, Fire, Lightning, or Thunder damage rather than its normal damage type and can force a STR save. On a failed save, you can move the target 10ft toward or away from you.
 			At level 11, you also gain a fly and swim speed equal to your speed for 10 minutes.</description>
 		</sheet>
 	</element>

--- a/2024-class-monk.xml
+++ b/2024-class-monk.xml
@@ -639,12 +639,12 @@
 		<description>
 			<p><em>3rd-level Warrior of the Elements feature</em></p>
 			<p>At the start of your turn, you can spend 1 Focus Point to imbue yourself with elemental energy. The energy lasts for 10 minutes or until you have the Incapacitated condition. You gain the following benefits for the duration:</p>
-			<p><strong>Elemental Strikes.</strong> Whenever you hit with your Unarmed Strike, you can cause it to deal your choice of Acid, Cold, Fire, or Lightning damage rather than its normal damage type. When you deal one of these types with your Unarmed Strike, you can also force the target to make a Strength saving throw. On a failed save, you can move the target up to 10 feet toward or away from you, as elemental energy swirls around it.</p>
+			<p><strong>Elemental Strikes.</strong> Whenever you hit with your Unarmed Strike, you can cause it to deal your choice of  Acid, Cold, Fire, Lightning, or Thunder damage rather than its normal damage type. When you deal one of these types with your Unarmed Strike, you can also force the target to make a Strength saving throw. On a failed save, you can move the target up to 10 feet toward or away from you, as elemental energy swirls around it.</p>
 			<p><strong>Reach.</strong> When you make an Unarmed Strike, your reach is 10 feet greater than normal, as elemental energy extends from you.</p>
 		</description>
 		<sheet usage="1 Focus">
-			<description>At start of turn, imbue yourself with elemental energy for 10 min. Unarmed reach increases by 10ft, Unarmed strikes can deal Acid, Cold, Fire, or Lightning damage rather than its normal damage type and can force a STR save or you can move the target 10ft toward or away from you.
-			You also gain a fly and swim speed equal to your speed for 10 minutes.</description>
+			<description>At start of turn, imbue yourself with elemental energy for 10 min. Unarmed reach increases by 10ft, Unarmed strikes can deal Acid, Cold, Fire, or Lightning damage rather than its normal damage type and can force a STR save. On a failed save, you can move the target 10ft toward or away from you.
+			At level 11, you also gain a fly and swim speed equal to your speed for 10 minutes.</description>
 		</sheet>
 	</element>
 	<element name="Manipulate Elements" type="Archetype Feature" source="2024 Player's Handbook" id="ID_2024PHB_ARCHETYPE_FEATURE_MANIPULATE_ELEMENTS">


### PR DESCRIPTION
Update 2024-class-monk.xml - Fixed typos in Elemental Warrior level 3. Added Thunder damage, and clarified that the forced movement is only on a failed save.